### PR TITLE
fix browse-preview.phtml to honor settings for components configured …

### DIFF
--- a/view/common/block-layout/browse-preview.phtml
+++ b/view/common/block-layout/browse-preview.phtml
@@ -40,22 +40,28 @@ $lang = $this->lang();
 
 <ul class="resources <?php echo ($isGrid) ? 'resource-grid' : 'resource-list'; ?>">
 <?php
+$showThumbnail = in_array('thumbnail', $this->components);
+$showHeading = in_array('resource-heading', $this->components);
+$showBody = in_array('resource-body', $this->components);
 $headingTerm = $this->siteSetting('browse_heading_property_term');
 $bodyTerm = $this->siteSetting('browse_body_property_term');
 foreach ($this->resources as $resource):
+	$thumbnail = $this->thumbnail($resource, 'medium');
     $heading = $headingTerm ? $resource->value($headingTerm, ['default' => $translate('[Untitled]')]) : $resource->displayTitle(null, ($filterLocale ? $lang : null));
     $body = $bodyTerm ? $resource->value($bodyTerm) : $resource->displayDescription(null, ($filterLocale ? $lang : null));
     
 ?>
     <li class="<?php echo $this->resourceType; ?> resource <?php echo ($isGrid) ? '' : 'media-object'; ?>">
-        <?php if ($thumbnail = $this->thumbnail($resource, 'medium')): ?>
+        <?php if ($showThumbnail && $thumbnail): ?>
         <div class="resource-image <?php echo ($isGrid) ? '' : 'media-object-section'; ?>">
             <?php echo $resource->linkRaw($thumbnail, null, ['class' => 'thumbnail']); ?>
         </div>
         <?php endif; ?>
         <div class="resource-meta <?php echo ($isGrid) ? '' : 'media-object-section'; ?>">
+            <?php if ($showHeading): ?>
             <h4><?php echo $resource->link($heading); ?></h4>
-            <?php if ($body): ?>
+            <?php endif;?>
+            <?php if ($showBody && $body): ?>
             <div class="description"><?php echo $escape($body); ?></div>
             <?php endif; ?>
         </div>


### PR DESCRIPTION
This PR is a fix for browse-preview.phtml to honor settings for components configured on edit page.

It adds variables for the 3 components shown on the browse preview block in the page edit, and add checks to display the component if selected.

Essentially copying the functionality from the default theme's browse-preview.phtml template. 

<img width="940" alt="Screen Shot 2023-02-10 at 9 21 03 AM" src="https://user-images.githubusercontent.com/20561037/218128489-74060dc5-78c2-490e-b937-a21ae67d5b45.png">
